### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744796498,
+        "narHash": "sha256-10VHCQvuIkmDbePV89iDh6vz7GnH2kNWXTb6Dhel/5c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6e4ad33281b279a5222d6b5f730399f9c62a00b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Command-line tool for extracting cookies from the user's web browser";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?tag=24.11";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in rec {
+          cookies = pkgs.buildGoModule rec {
+            pname = "cookies";
+            version = "0.5.1";
+            src = ./.;
+            vendorHash = "sha256-lFRZW2KtVsZLHq4oLyDUjFmIpkWuMlIjNuFxLvUp2wg=";
+          };
+
+          default = cookies;
+        }
+      );
+    };
+}


### PR DESCRIPTION
This adds a flake.nix to make it possible to directly run the repo via `nix run github:barnardb/cookies`.